### PR TITLE
Add drainage and foundation option support

### DIFF
--- a/carport-configurator/backend/app.py
+++ b/carport-configurator/backend/app.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
-from models.config import CarportConfig
+from models.config import CarportConfig, CarportResponse
 from utils.calculation import (
     fetch_solar_data,
     compute_optimal_tilt,
     compute_pv_yield,
 )
+from utils.options import list_drainage_options, list_foundation_options
 
 app = FastAPI()
 
@@ -12,17 +13,21 @@ app = FastAPI()
 def read_health():
     return {"status": "ok"}
 
-@app.post("/configure")
-async def configure(config: CarportConfig):
+@app.post("/configure", response_model=CarportResponse)
+async def configure(config: CarportConfig) -> CarportResponse:
     solar_data = await fetch_solar_data(config.postal_code)
     optimal_tilt = compute_optimal_tilt(solar_data)
     estimated_yield = compute_pv_yield(optimal_tilt, config.pv_modules, solar_data)
+    drainage_options = list_drainage_options(config.material, config.roof_shape)
+    foundation_options = list_foundation_options(config.material, config.roof_shape)
 
-    return {
-        "material": config.material,
-        "roof_shape": config.roof_shape,
-        "pv_modules": config.pv_modules,
-        "postal_code": config.postal_code,
-        "optimal_tilt": optimal_tilt,
-        "estimated_yield": estimated_yield,
-    }
+    return CarportResponse(
+        material=config.material,
+        roof_shape=config.roof_shape,
+        pv_modules=config.pv_modules,
+        postal_code=config.postal_code,
+        optimal_tilt=optimal_tilt,
+        estimated_yield=estimated_yield,
+        drainage_options=drainage_options,
+        foundation_options=foundation_options,
+    )

--- a/carport-configurator/models/config.py
+++ b/carport-configurator/models/config.py
@@ -6,3 +6,10 @@ class CarportConfig(BaseModel):
     roof_shape: str
     pv_modules: List[str]
     postal_code: str
+
+
+class CarportResponse(CarportConfig):
+    optimal_tilt: float
+    estimated_yield: float
+    drainage_options: List[str]
+    foundation_options: List[str]

--- a/carport-configurator/utils/options.py
+++ b/carport-configurator/utils/options.py
@@ -1,0 +1,41 @@
+from typing import List
+
+
+def list_drainage_options(material: str, roof_shape: str) -> List[str]:
+    """Return drainage options based on material and roof shape."""
+    options: List[str] = []
+    material_l = material.lower()
+    roof_l = roof_shape.lower()
+
+    if roof_l == "flachdach":
+        options.append("Innenliegende Dachrinne")
+    else:
+        options.append("Au\u00dfenliegende Dachrinne")
+
+    if material_l == "holz":
+        options.append("Kupferrinne")
+    elif material_l == "aluminium":
+        options.append("Alu-Rinne")
+    else:
+        options.append("Stahl-Rinne")
+
+    return options
+
+
+def list_foundation_options(material: str, roof_shape: str) -> List[str]:
+    """Return foundation options based on material and roof shape."""
+    options: List[str] = []
+    material_l = material.lower()
+    roof_l = roof_shape.lower()
+
+    if material_l == "holz":
+        options.extend(["Punktfundament", "Erdanker"])
+    elif material_l == "aluminium":
+        options.extend(["Schraubfundament", "Betonfundament"])
+    else:
+        options.extend(["Streifenfundament", "Betonfundament"])
+
+    if roof_l == "flachdach":
+        options.append("Bodenplatte")
+
+    return options


### PR DESCRIPTION
## Summary
- add utility functions for drainage and foundation options
- extend Pydantic models with response model
- update `/configure` endpoint to return options

## Testing
- `python -m pip install -r carport-configurator/requirements.txt`
- `python -m py_compile carport-configurator/backend/app.py carport-configurator/models/config.py carport-configurator/utils/options.py`
- `python - <<'PY'
import sys
sys.path.append('carport-configurator')
from utils.options import list_drainage_options, list_foundation_options
print(list_drainage_options('Holz', 'Flachdach'))
print(list_foundation_options('Holz', 'Satteldach'))
PY` *(fails: 403 Forbidden when contacting api.zippopotam.us)*

------
https://chatgpt.com/codex/tasks/task_e_684be3a7ab8c8331bce9635101e726d6