### PR TITLE
Add PDF generator and download endpoint

### DIFF
--- a/carport-configurator/Dockerfile
+++ b/carport-configurator/Dockerfile
@@ -10,4 +10,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8000 8501
+CMD ["sh", "-c", "uvicorn backend.app:app --host 0.0.0.0 --port 8000 & streamlit run frontend/app.py --server.address 0.0.0.0 --server.port 8501"]

--- a/carport-configurator/README.md
+++ b/carport-configurator/README.md
@@ -24,6 +24,25 @@ uvicorn backend.app:app --reload
 
 Frontend über Streamlit starten:
 ```bash
-streamlit run frontend/main.py
+streamlit run frontend/app.py
 ```
+
+## Docker
+
+Die Anwendung kann auch komplett in einem Container gebaut und gestartet werden.
+
+Zum Erstellen des Images im Projektverzeichnis ausführen:
+
+```bash
+docker build -t carport-configurator .
+```
+
+Anschließend lässt sich der Container starten:
+
+```bash
+docker run -p 8000:8000 -p 8501:8501 carport-configurator
+```
+
+Das Backend ist dann unter `http://localhost:8000` erreichbar und das
+Frontend unter `http://localhost:8501`.
 

--- a/carport-configurator/backend/app.py
+++ b/carport-configurator/backend/app.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
+from fastapi.responses import StreamingResponse
+from io import BytesIO
 from models.config import CarportConfig, CarportResponse
 from utils.calculation import (
     fetch_solar_data,
@@ -6,6 +8,7 @@ from utils.calculation import (
     compute_pv_yield,
 )
 from utils.options import list_drainage_options, list_foundation_options
+from utils.pdf_generator import generate_material_list_pdf
 
 app = FastAPI()
 
@@ -31,3 +34,24 @@ async def configure(config: CarportConfig) -> CarportResponse:
         drainage_options=drainage_options,
         foundation_options=foundation_options,
     )
+
+
+@app.get("/download")
+async def download(config: CarportConfig = Depends()):
+    """Generate and return a material list PDF."""
+    solar_data = await fetch_solar_data(config.postal_code)
+    optimal_tilt = compute_optimal_tilt(solar_data)
+    estimated_yield = compute_pv_yield(optimal_tilt, config.pv_modules, solar_data)
+    drainage_options = list_drainage_options(config.material, config.roof_shape)
+    foundation_options = list_foundation_options(config.material, config.roof_shape)
+
+    pdf_bytes = generate_material_list_pdf(
+        config.dict(),
+        {"optimal_tilt": optimal_tilt, "estimated_yield": estimated_yield},
+        {
+            "drainage_options": drainage_options,
+            "foundation_options": foundation_options,
+        },
+    )
+
+    return StreamingResponse(BytesIO(pdf_bytes), media_type="application/pdf")

--- a/carport-configurator/utils/pdf_generator.py
+++ b/carport-configurator/utils/pdf_generator.py
@@ -1,0 +1,60 @@
+from io import BytesIO
+from typing import Any, Dict
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib import colors
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
+
+
+def generate_material_list_pdf(config_data: Dict[str, Any], calculation_results: Dict[str, Any], options: Dict[str, Any]) -> bytes:
+    """Generate a simple material list PDF.
+
+    Parameters
+    ----------
+    config_data: Dict[str, Any]
+        Original configuration values.
+    calculation_results: Dict[str, Any]
+        Calculated results such as tilt or PV yield.
+    options: Dict[str, Any]
+        Additional options lists.
+    Returns
+    -------
+    bytes
+        The generated PDF as bytes.
+    """
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(buffer, pagesize=A4)
+    styles = getSampleStyleSheet()
+    elements = []
+
+    elements.append(Paragraph("Materialliste", styles["Title"]))
+    elements.append(Spacer(1, 12))
+
+    def section(title: str, data: Dict[str, Any]):
+        elements.append(Paragraph(title, styles["Heading2"]))
+        table_data = [["Schlüssel", "Wert"]]
+        for key, value in data.items():
+            if isinstance(value, list):
+                value = ", ".join(str(v) for v in value)
+            table_data.append([str(key), str(value)])
+        table = Table(table_data, hAlign="LEFT")
+        table.setStyle(
+            TableStyle([
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ])
+        )
+        elements.append(table)
+        elements.append(Spacer(1, 12))
+
+    section("Konfiguration", config_data)
+    section("Berechnung", calculation_results)
+    section("Optionen", options)
+
+    doc.build(elements)
+    pdf_bytes = buffer.getvalue()
+    buffer.close()
+    return pdf_bytes


### PR DESCRIPTION
## Summary
- generate a PDF material list using ReportLab
- serve PDF from new GET `/download` endpoint
- run backend and Streamlit frontend together in container
- document Docker build and run steps

## Testing
- `python -m py_compile carport-configurator/backend/app.py carport-configurator/utils/calculation.py carport-configurator/utils/options.py carport-configurator/utils/pdf_generator.py carport-configurator/frontend/app.py carport-configurator/models/config.py`

------
https://chatgpt.com/codex/tasks/task_e_684be4630ab08331acf3aa5e9bf3dce2