### PR TITLE
Add Hornbach style theme

### DIFF
--- a/carport-configurator/frontend/app.py
+++ b/carport-configurator/frontend/app.py
@@ -1,7 +1,12 @@
 import streamlit as st
 import httpx
+from pathlib import Path
 
 st.set_page_config(page_title="Carport Konfigurator")
+
+# Load and apply Hornbach theme
+style_path = Path(__file__).parent / "style.css"
+st.markdown(f"<style>{style_path.read_text()}</style>", unsafe_allow_html=True)
 
 MATERIAL_OPTIONS = ["Holz", "Aluminium", "Stahl"]
 ROOF_OPTIONS = ["Flachdach", "Satteldach", "Walmdach"]

--- a/carport-configurator/frontend/style.css
+++ b/carport-configurator/frontend/style.css
@@ -1,0 +1,39 @@
+:root {
+    --color-primary: #F26621;
+    --color-secondary: #000000;
+    --font-family-base: Arial, sans-serif;
+}
+
+body {
+    font-family: var(--font-family-base);
+    background-color: #ffffff;
+    color: var(--color-secondary);
+    margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: var(--color-primary);
+    margin-top: 0;
+}
+
+p {
+    color: var(--color-secondary);
+    line-height: 1.6;
+}
+
+button, .stButton > button {
+    background-color: var(--color-primary);
+    color: #ffffff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover, .stButton > button:hover {
+    background-color: #d95b1c;
+}
+
+.stApp {
+    background-color: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- add `style.css` with Hornbach-inspired theme
- inject stylesheet in Streamlit app so the theme loads automatically

## Testing
- `python3 -m py_compile carport-configurator/frontend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684be93fde008331bcffea3c72d000bb