### PR TITLE
Add sidebar with form and styling

### DIFF
--- a/carport-configurator/frontend/app.py
+++ b/carport-configurator/frontend/app.py
@@ -42,30 +42,28 @@ MATERIAL_OPTIONS = ["Holz", "Aluminium", "Stahl"]
 ROOF_OPTIONS = ["Flachdach", "Satteldach", "Walmdach"]
 PV_OPTIONS = ["Mono", "Poly", "Glas-Glas"]
 
-with st.form("config_form"):
-    col1, col2 = st.columns(2)
-    with col1:
+with st.sidebar:
+    with st.form("config_form"):
         material = st.selectbox(
             "Material",
             MATERIAL_OPTIONS,
             key="material",
         )
-    with col2:
         roof_shape = st.selectbox(
             "Dachform",
             ROOF_OPTIONS,
             key="roof_shape",
         )
-    pv_modules = st.multiselect(
-        "PV-Module",
-        PV_OPTIONS,
-        key="pv_modules",
-    )
-    postal_code = st.text_input(
-        "Postleitzahl",
-        key="postal_code",
-    )
-    submitted = st.form_submit_button("Berechnen")
+        pv_modules = st.multiselect(
+            "PV-Module",
+            PV_OPTIONS,
+            key="pv_modules",
+        )
+        postal_code = st.text_input(
+            "Postleitzahl",
+            key="postal_code",
+        )
+        submitted = st.form_submit_button("Berechnen", use_container_width=True)
 
 if submitted:
     payload = {

--- a/carport-configurator/frontend/style.css
+++ b/carport-configurator/frontend/style.css
@@ -37,3 +37,33 @@ button:hover, .stButton > button:hover {
 .stApp {
     background-color: #f5f5f5;
 }
+
+/* Sidebar styling */
+div[data-testid='stSidebar'] {
+    background-color: #000000;
+    color: #ffffff;
+}
+
+div[data-testid='stSidebar'] label {
+    color: #ffffff;
+}
+
+div[data-testid='stSidebar'] input,
+div[data-testid='stSidebar'] textarea,
+div[data-testid='stSidebar'] select,
+div[data-testid='stSidebar'] .stMultiSelect div[data-baseweb] {
+    border-radius: 8px !important;
+}
+
+div[data-testid='stSidebar'] input:hover,
+div[data-testid='stSidebar'] textarea:hover,
+div[data-testid='stSidebar'] select:hover,
+div[data-testid='stSidebar'] .stMultiSelect div[data-baseweb]:hover {
+    border-color: var(--color-primary) !important;
+    box-shadow: 0 0 0 0.2rem rgba(242, 102, 33, 0.25);
+}
+
+div[data-testid='stSidebar'] button {
+    width: 100%;
+    font-size: 1.2rem;
+}


### PR DESCRIPTION
## Summary
- move configuration form into the sidebar
- style sidebar in black with white text
- apply rounded corners and orange hover for inputs
- enlarge the calculate button

## Testing
- `python -m py_compile carport-configurator/frontend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684bebac97988331a169312a0be62b93