### PR TITLE
Add result cards and PDF download

### DIFF
--- a/carport-configurator/frontend/app.py
+++ b/carport-configurator/frontend/app.py
@@ -81,4 +81,63 @@ if submitted:
 
 if "result" in st.session_state:
     st.subheader("Ergebnis")
-    st.json(st.session_state["result"])
+    result = st.session_state["result"]
+
+    col1, col2 = st.columns(2)
+
+    with col1:
+        st.markdown(
+            f"""
+            <div class="card">
+                <h3>Optimale Neigung</h3>
+                <p>{result['optimal_tilt']}°</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.markdown(
+            f"""
+            <div class="card">
+                <h3>Drainage-Optionen</h3>
+                <p>{', '.join(result['drainage_options'])}</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    with col2:
+        st.markdown(
+            f"""
+            <div class="card">
+                <h3>Ertrag</h3>
+                <p>{result['estimated_yield']}</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.markdown(
+            f"""
+            <div class="card">
+                <h3>Fundament-Optionen</h3>
+                <p>{', '.join(result['foundation_options'])}</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    import urllib.parse
+
+    query = urllib.parse.urlencode(
+        {
+            "material": result["material"],
+            "roof_shape": result["roof_shape"],
+            "pv_modules": result["pv_modules"],
+            "postal_code": result["postal_code"],
+        },
+        doseq=True,
+    )
+    download_url = f"http://localhost:8000/download?{query}"
+    st.markdown(
+        f'<a href="{download_url}"><button>PDF herunterladen</button></a>',
+        unsafe_allow_html=True,
+    )

--- a/carport-configurator/frontend/style.css
+++ b/carport-configurator/frontend/style.css
@@ -67,3 +67,12 @@ div[data-testid='stSidebar'] button {
     width: 100%;
     font-size: 1.2rem;
 }
+
+/* Result cards styling */
+.card {
+    background-color: #ffffff;
+    border: 1px solid #000000;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- show calculation results as nicely styled cards
- add 'PDF herunterladen' button that links to the `/download` endpoint
- style cards in CSS

## Testing
- `python -m py_compile carport-configurator/frontend/app.py`
- `python -m py_compile carport-configurator/backend/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bec54bbc88331bcbda4ae3b2c7e2d